### PR TITLE
herokuへのデプロイを実施(現時点ではdb生成が上手くいっていない)#44

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,10 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
+  #Herokuでアプリケーションにアクセスした際の最初に開くページを設定
+  config.assets.compile = true
+  config.assets.initialize_on_precompile=false
+
   if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter


### PR DESCRIPTION
<参考資料>
Title: Herokuへのデプロイ方法【Heroku+Rails+MySQL】
URL: https://qiita.com/murakami-mm/items/9587e21fc0ed57c803d0

rootのhtmlは表示されるも各機能の画面遷移のボタンをクリックすると「We're sorry, but something went wrong.
If you are the application owner check the logs for more information.」が表示される。
恐らくdb nameなどの設定が上手くできていないと推測している

#44 