### PR TITLE
ユーザー一覧ページの追加#21

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+
+  def index
+    @users = User.all.page(params[:page]).per(6)
+  end
+
   def show
     @user = User.find(params[:id])
   end

--- a/app/views/devise/registrations/index.html.erb
+++ b/app/views/devise/registrations/index.html.erb
@@ -1,8 +1,0 @@
-<h1>Posts#index</h1>
-<h2>ユーザー一覧</h2>
-<p>Find me in app/views/posts/index.html.erb</p>
-<% @users.each do |user| %>
-  <p>name：<%= user.name %>
-    / id：<%= user.id %></p>
-<% end %>
-<%= paginate @users %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,6 @@
+<% @users.each do |user| %>
+  <p><%= link_to user.name,user_path(current_user) %></p>
+    <p>id：<%= user.id %></p>
+<% end %>
+<%= paginate @users %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,14 +10,13 @@ Rails.application.routes.draw do
   devise_scope :user do
     post 'users/guest_sign_in', to: 'devise/sessions#new_guest'
     #showのみPrefixが省略されていたため、asを利用し明示的に指定。
-    #一旦、以下をオリジナルUserに記述
     #get 'users/:id/show', to: 'devise/registrations#show', :as => :show_user_registration
-    get 'users', to: 'devise/registrations#index'
   end
 
   resources :users do
     member do
       get :following, :followers
+      get 'users', to:'users/#index'
     end
   end
 


### PR DESCRIPTION
indexアクションをdevise gem ライブラリに直接追加していたため、独自に作成した users コントローラーに移行。
一旦、UI部分は触らずUser.nameをクリックしたらユーザー詳細ページに移動するようにlink_toで実装。