### PR TITLE
お気に入り機能とダイレクト機能のエラー回避#51 ＆ #

### DIFF
--- a/.idea/shelf/Uncommitted_changes_before_Checkout_at_2020_08_21_22_56__Default_Changelist_.xml
+++ b/.idea/shelf/Uncommitted_changes_before_Checkout_at_2020_08_21_22_56__Default_Changelist_.xml
@@ -1,0 +1,4 @@
+<changelist name="Uncommitted_changes_before_Checkout_at_2020_08_21_22_56_[Default_Changelist]" date="1598018178820" recycled="true" deleted="true">
+  <option name="PATH" value="$PROJECT_DIR$/.idea/shelf/Uncommitted_changes_before_Checkout_at_2020_08_21_22_56_[Default_Changelist]/shelved.patch" />
+  <option name="DESCRIPTION" value="Uncommitted changes before Checkout at 2020/08/21 22:56 [Default Changelist]" />
+</changelist>

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -4,6 +4,7 @@ class FavoritesController < ApplicationController
   # お気に入り
   # Favoriteモデルにuser_idとpost_idを格納
   def create
+    @post = Post.find(params[:post_id])
     @favorite = current_user.favorites.create(post_id: params[:post_id])
   end
 
@@ -12,5 +13,7 @@ class FavoritesController < ApplicationController
   def destroy
     @favorite = Favorite.find_by(post_id: params[:post_id], user_id: current_user.id)
     @favorite.destroy
+    @post = Post.find(params[:post_id])
   end
 end
+

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,6 +8,6 @@ class MessagesController < ApplicationController
     else
       flash[:alert] = "メッセージ送信に失敗しました。"
     end
-    　　redirect_to "/rooms/#{@message.room_id}"
+    redirect_to "/rooms/#{@message.room_id}"
   end
 end

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,5 +1,5 @@
-<% if current_user.already_favorited?(@post) %>
-  <%= button_to 'いいねを取り消す', post_favorite_path(@post), method: :delete, remote: true %>
+<% if current_user.already_favorited?(post) %>
+  <%= button_to 'いいねを取り消す', post_favorites_path(post), method: :delete, remote: true %>
 <% else %>
-  <%= button_to 'いいねを登録する', post_favorites_path(@post), method: :post, remote: true %>
+  <%= button_to 'いいねを登録する', post_favorites_path(post), method: :post, remote: true %>
 <% end %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,11 +1,11 @@
 <div class="left-button">
-  <%= link_to "ユーザー一覧に戻る", "/users/index",class:"edit-link" %>
+  <%= link_to "ユーザー一覧に戻る", "/users/index", class: "edit-link" %>
 </div>
 <h4 class="rooms-title">気になる同士</h4>
 <% @entries.each do |e| %>
   <div class="user-name">
     <strong>
-      <%= image_tag current_user.image.to_s, class:"user-image" %>
+      <%= image_tag current_user.image.to_s, class: "user-image" %>
       <a class="rooms-user-link" href="/users/<%= e.user.id %>">
         <%= e.user.name %>さん
       </a>
@@ -19,10 +19,12 @@
       <% @messages.each do |m| %>
         <div class="chat-box">
           <div class="chat-face">
-            <%= image_tag m.user.image, class:"user-image" %>
+            <% if m.user.image? %>
+              <%= image_tag m.user.image.to_s, class: "user-image" %>
+            <% end %>
           </div>
-          <div class="chat-hukidashi"> <strong><%= m.content %></strong> <br>
-            <%= m.created_at.strftime("%Y-%m-%d %H:%M")%>
+          <div class="chat-hukidashi"><strong><%= m.content %></strong> <br>
+            <%= m.created_at.strftime("%Y-%m-%d %H:%M") %>
           </div>
         </div>
       <% end %>
@@ -30,9 +32,9 @@
   </div>
   <div class="posts">
     <%= form_for @message do |f| %>
-      <%= f.text_field :content, placeholder: "メッセージを入力して下さい" , size: 70, class:"form-text-field" %>
+      <%= f.text_field :content, placeholder: "メッセージを入力して下さい", size: 70, class: "form-text-field" %>
       <%= f.hidden_field :room_id, value: @room.id %>
-      <%= f.submit "投稿",class: 'form-submit'%>
+      <%= f.submit "投稿", class: 'form-submit' %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   resources :rooms, only: [:create,:show]
 
   resources :posts do
-    resources :favorites, only: [:create, :destroy]
+    resource :favorites, only: [:create, :destroy]
     resources :comments, only: [:create, :destroy]
   end
 end

--- a/db/migrate/20200822144631_add_content_to_message.rb
+++ b/db/migrate/20200822144631_add_content_to_message.rb
@@ -1,0 +1,5 @@
+class AddContentToMessage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :messages, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_20_142015) do
+ActiveRecord::Schema.define(version: 2020_08_22_144631) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "content"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_08_20_142015) do
     t.bigint "room_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "content"
     t.index ["room_id"], name: "index_messages_on_room_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end


### PR DESCRIPTION
お気に入り機能についてはリロードしないとAjaxが発火しない状況でRails server エラーではpost_idがnilとなっていた。
対処：routesファイルにresources :favoritesと記載をしていたため、URLもpost_idが必要な状態(引数が足りていない状態)となっていた。そのため resources :favorites とすることにより、urlに:idを含まなくしエラーを回避。

<参考情報>
resourceとresourcesの違い
https://qiita.com/ryuuuuuuuuuu/items/e5960c7fecad4ef1301b

お気に入り機能についてもう一つの問題がAjaxが発火せずリロードをする必要があった箇所。
対処：Javascript(create.js.erb及びdestory.js.erb)のハッシュで送信しているのが"locals: {post: @post })"となっているにも関わらず部分テンプレート (favorite.html.erb)では@postと記述されていたため、postに修正。

ダイレクトメッセージ機能については、contentカラムがmessageテーブルに存在していなかったためエラーが発生していたため、追加し実装完了。
#51 #92 