### PR TITLE
google maps api 新規投稿ページにてlatitude longitudeのhiddenを設定#106

### DIFF
--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -15,6 +15,9 @@
     <div id="map" style="width:640px; height:320px"></div>
   </div>
 
+  <input type="hidden" name="latitude" value="1.1" />
+  <input type="hidden" name="longitude" value="2.2" />
+
   <!--星評価機能フォーム-->
   <div class="form-group row" id="star">
     <%= f.label :rate, '評価', class: "col-md-3 col-form-label" %>


### PR DESCRIPTION
<form>タグを用いると submit が反応せずサーバー側のエラーも確認できないため下記のみ挿入。

```ruby
  <input type="hidden" name="latitude" value="1.1" />
  <input type="hidden" name="longitude" value="2.2" />
```

#106 